### PR TITLE
updated BProgressbar, Trustscore is in DisplayResults

### DIFF
--- a/src/components/Progressbar/BProgressBar.js
+++ b/src/components/Progressbar/BProgressBar.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
 function BProgressBar(props) {
   const classes = useStyles();
 
-  let percentage = (100 - props.Bscore);
+  let percentage = props.Bscore;
   let fgcolor;
 
   if (percentage < 30) {


### PR DESCRIPTION
removing conversion in BPogressbar Branch as TrustScore is now calculated at DisplayResults component