### PR TITLE
Add conditional display to category

### DIFF
--- a/src/components/Results/Credibility.js
+++ b/src/components/Results/Credibility.js
@@ -134,7 +134,7 @@ function Credibility(props) {
                  written in the reasoning section for that source.`;
         break;
       default:
-        categoryText = `Not enough information about this source exists to calculate a score`;
+        categoryText = false;
     }
   };
   categoryText();
@@ -178,6 +178,7 @@ function Credibility(props) {
             </Tooltip>
           </Grid>
         </Grid>
+        {categoryText && 
         <Grid item xs={12}>
           <Grid
             container
@@ -210,6 +211,7 @@ function Credibility(props) {
             </Grid>
           </Grid>
         </Grid>
+        }
         <Grid item xs={12}>
           <Typography variant="subtitle2" className={classes.categoryTitle}>
             Source:{" "}


### PR DESCRIPTION
Conditionally hides the category section if it's not a category type we recognize/have text for:

![image](https://user-images.githubusercontent.com/272156/97920215-0b0eae00-1d51-11eb-9579-2e7881bbb42b.png)

...otherwise shows the category chip and the tooltip:

![image](https://user-images.githubusercontent.com/272156/97920288-21b50500-1d51-11eb-87e1-6d13b410016b.png)

